### PR TITLE
Add webview example with custom JS namespace

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,5 @@
+# Example
+
+This sample demonstrates how to use `flutter_inappwebview` with a custom
+JavaScript namespace (`window.nshub.callbackHandler`) for WebView
+communication.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: WebViewPage(),
+    );
+  }
+}
+
+class WebViewPage extends StatefulWidget {
+  const WebViewPage({super.key});
+
+  @override
+  State<WebViewPage> createState() => _WebViewPageState();
+}
+
+class _WebViewPageState extends State<WebViewPage> {
+  late final InAppWebViewController _controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Nsmall WebView')),
+      body: InAppWebView(
+        initialUrlRequest: URLRequest(url: WebUri('https://m.nsmall.com')),
+        onWebViewCreated: (controller) {
+          _controller = controller;
+          _controller.addJavaScriptHandler(
+            handlerName: 'callbackHandler',
+            callback: (args) {
+              // Handle messages from the webpage here.
+              debugPrint('Received message: $args');
+              return 'Response from Flutter';
+            },
+          );
+        },
+        onLoadStop: (controller, url) async {
+          await controller.evaluateJavascript(source: _wrapperScript);
+        },
+      ),
+    );
+  }
+
+  static const String _wrapperScript = '''
+  window.nshub = {
+    callbackHandler: function() {
+      return window.flutter_inappwebview.callHandler('callbackHandler', ...arguments);
+    }
+  };
+  ''';
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,15 @@
+name: webview_custom_interface_example
+publish_to: "none"
+
+environment:
+  sdk: "^3.1.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_inappwebview: ^6.0.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/


### PR DESCRIPTION
## Summary
- add sample Flutter project showing how to use a custom JavaScript namespace with `flutter_inappwebview`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68477761bd8c8329bd7ff4063646255f